### PR TITLE
Allow the use of custom packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_self_serve_access_keys"></a> [self\_serve\_access\_keys](#module\_self\_serve\_access\_keys) | git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys | v0.1.0 |
 
 ## Resources
 
@@ -23,6 +25,7 @@ No modules.
 | [aws_iam_user.elasticsearch_iam_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.elasticsearch_iam_user_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_security_group.elasticsearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_iam_policy_document.elasticsearch_iam_user_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -47,6 +50,8 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the elasticsearch cluster | `string` | n/a | yes |
 | <a name="input_node_to_node_encryption_enabled"></a> [node\_to\_node\_encryption\_enabled](#input\_node\_to\_node\_encryption\_enabled) | Whether to enable node-to-node encryption | `string` | `"false"` | no |
 | <a name="input_require_https"></a> [require\_https](#input\_require\_https) | Determines whether https required for connections to this domain | `string` | `"false"` | no |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | Allow ES user to get objects from specified bucket | `any` | `null` | no |
+| <a name="input_s3_bucket_kms_key"></a> [s3\_bucket\_kms\_key](#input\_s3\_bucket\_kms\_key) | Allow ES user to use specified KMS key to decrypt objects from given bucket | `any` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The list of subnet IDs associated to a vpc, for vpc domains | `list` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the resources within | `any` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -86,20 +86,59 @@ resource "aws_iam_user_policy" "elasticsearch_iam_user_policy" {
   name = "${aws_iam_user.elasticsearch_iam_user.name}-policy"
   user = aws_iam_user.elasticsearch_iam_user.name
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "es:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_elasticsearch_domain.elasticsearch.arn}"
-    }
-  ]
+  policy = data.aws_iam_policy_document.elasticsearch_iam_user_policy_document.json
 }
-EOF
+
+data "aws_iam_policy_document" "elasticsearch_iam_user_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:AssociatePackage",
+      "es:Describe*",
+      "es:DissociatePackage",
+      "es:ListPackagesForDomain",
+    ]
+
+    resources = [aws_elasticsearch_domain.elasticsearch.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "es:CreatePackage",
+      "es:DescribePackages",
+    ]
+
+    resources = ["*"]
+  }
+
+  dynamic statement {
+    for_each = var.s3_bucket != null ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+      ]
+
+      resources = ["${var.s3_bucket}/*"]
+    }
+  }
+
+  dynamic statement {
+    for_each = var.s3_bucket_kms_key != null ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:GetKeyPolicy",
+        "kms:GenerateDataKeyWithoutPlaintext",
+      ]
+
+      resources = [var.s3_bucket_kms_key]
+    }
+  }
 }
 
 resource "aws_elasticsearch_domain_policy" "elasticsearch" {

--- a/variable.tf
+++ b/variable.tf
@@ -126,3 +126,13 @@ variable "key_rotation" {
   description = "Enable email notifications for old IAM keys."
   default     = "true"
 }
+
+variable "s3_bucket" {
+  description = "Allow ES user to get objects from specified bucket"
+  default     = null
+}
+
+variable "s3_bucket_kms_key" {
+  description = "Allow ES user to use specified KMS key to decrypt objects from given bucket"
+  default     = null
+}


### PR DESCRIPTION
Allows https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/custom-packages.html

Does not allow deleting or updating packages as at the moment, you cannot stop IAM users from deleting/updating packages they did not create.