### PR TITLE
ACPENG-1153 - Multiple IAM users option with custom policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Version 2 the input variable tls_security_policy was implemented with a default 
 | <a name="input_email_addresses"></a> [email\_addresses](#input\_email\_addresses) | A list of email addresses for key rotation notifications. | `list(string)` | `[]` | no |
 | <a name="input_encrypt_at_rest_enabled"></a> [encrypt\_at\_rest\_enabled](#input\_encrypt\_at\_rest\_enabled) | Whether to enable encryption at rest | `string` | `"false"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment the elasticsearch cluster is running in i.e. dev, prod etc | `any` | n/a | yes |
-| <a name="input_iam_users"></a> [iam\_users](#input\_iam\_users) | IAM users to create and their indexes/policies | <pre>map(list(object({<br>    actions = list(string)<br>    indexes = list(string)<br>  })))</pre> | n/a | yes |
+| <a name="input_iam_users"></a> [iam\_users](#input\_iam\_users) | IAM users to create and their allowed HTTP paths and methods | <pre>map(list(object({<br>    http_methods = list(string)<br>    http_paths   = list(string)<br>  })))</pre> | n/a | yes |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of data nodes in the cluster | `number` | `4` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Elasticsearch instance type for data nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | <a name="input_internal_user_database_enabled"></a> [internal\_user\_database\_enabled](#input\_internal\_user\_database\_enabled) | Enable the internal user database | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Version 2 the input variable tls_security_policy was implemented with a default 
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_elasticsearch_iam_users_policy_self_serve_access"></a> [elasticsearch\_iam\_users\_policy\_self\_serve\_access](#module\_elasticsearch\_iam\_users\_policy\_self\_serve\_access) | git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys | v0.1.0 |
 | <a name="module_self_serve_access_keys"></a> [self\_serve\_access\_keys](#module\_self\_serve\_access\_keys) | git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys | v0.1.0 |
 
 ## Resources
@@ -33,11 +34,14 @@ Version 2 the input variable tls_security_policy was implemented with a default 
 | [aws_iam_policy.elasticsearch_audit_log_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.elasticsearch_audit_logs_iam_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.elasticsearch_iam_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.elasticsearch_iam_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy.elasticsearch_iam_user_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
+| [aws_iam_user_policy.elasticsearch_iam_users_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_iam_user_policy_attachment.elasticsearch_audit_log_policy_attachement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_security_group.elasticsearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_iam_policy_document.elasticsearch_default_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elasticsearch_iam_user_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.elasticsearch_iam_users_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -57,6 +61,7 @@ Version 2 the input variable tls_security_policy was implemented with a default 
 | <a name="input_email_addresses"></a> [email\_addresses](#input\_email\_addresses) | A list of email addresses for key rotation notifications. | `list(string)` | `[]` | no |
 | <a name="input_encrypt_at_rest_enabled"></a> [encrypt\_at\_rest\_enabled](#input\_encrypt\_at\_rest\_enabled) | Whether to enable encryption at rest | `string` | `"false"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment the elasticsearch cluster is running in i.e. dev, prod etc | `any` | n/a | yes |
+| <a name="input_iam_users"></a> [iam\_users](#input\_iam\_users) | IAM users to create and their indexes/policies | <pre>map(list(object({<br>    actions = list(string)<br>    indexes = list(string)<br>  })))</pre> | n/a | yes |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of data nodes in the cluster | `number` | `4` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Elasticsearch instance type for data nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | <a name="input_internal_user_database_enabled"></a> [internal\_user\_database\_enabled](#input\_internal\_user\_database\_enabled) | Enable the internal user database | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ resource "aws_iam_user_policy" "elasticsearch_iam_users_policy" {
   for_each = local.iam_users_map
 
   name = "${var.name}-${each.value.name_suffix}-policy"
-  user = aws_iam_user.elasticsearch_iam_users[each.key]
+  user = aws_iam_user.elasticsearch_iam_users[each.key].name
 
   policy = data.aws_iam_policy_document.elasticsearch_iam_users_policy[each.key].json
 }

--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,6 @@ data "aws_iam_policy_document" "elasticsearch_iam_users_policy" {
     for_each = each.value
 
     content {
-      sid    = "IAMUserPolicies"
       effect = "Allow"
 
       actions = statement.value.actions

--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,6 @@ resource "aws_iam_user" "elasticsearch_iam_users" {
 
 data "aws_iam_policy_document" "elasticsearch_iam_users_policy" {
   for_each = local.iam_users_map
-  name     = "${var.name}-${each.value.name_suffix}"
 
   statement {
     sid    = "IAMUserPolicies"

--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ locals {
 
 resource "aws_iam_user" "elasticsearch_iam_users" {
   for_each = local.iam_users_map
-  name     = "${var.name}-${each.value.name_suffix}"
+  name     = "${var.name}-${each.value.name_suffix}-iam-user"
 
   tags = merge(
     var.tags,

--- a/main.tf
+++ b/main.tf
@@ -241,6 +241,8 @@ resource "aws_iam_user_policy" "elasticsearch_iam_users_policy" {
 }
 
 module "elasticsearch_iam_users_policy_self_serve_access" {
+  for_each = var.iam_users
+
   source     = "git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys?ref=v0.1.0"
-  user_names = [for user in aws_iam_user.elasticsearch_iam_users : user.name]
+  user_names = [aws_iam_user.elasticsearch_iam_users[each.key].name]
 }

--- a/main.tf
+++ b/main.tf
@@ -223,9 +223,9 @@ data "aws_iam_policy_document" "elasticsearch_iam_users_policy" {
     content {
       effect = "Allow"
 
-      actions = statement.value.actions
+      actions = [for method in statement.value.http_methods : format("es:ESHttp%s", method)]
 
-      resources = [for index in statement.value.indexes : format("${aws_elasticsearch_domain.elasticsearch.arn}/%s", index)]
+      resources = [for path in statement.value.http_paths : format("${aws_elasticsearch_domain.elasticsearch.arn}/%s", path)]
     }
   }
 }

--- a/variable.tf
+++ b/variable.tf
@@ -192,7 +192,7 @@ variable "iam_users" {
     http_methods = list(string)
     http_paths   = list(string)
   })))
-  description = "IAM users to create and their indexes/actions"
+  description = "IAM users to create and their allowed HTTP paths and methods"
 
   validation {
     condition = alltrue(

--- a/variable.tf
+++ b/variable.tf
@@ -188,9 +188,9 @@ variable "tls_security_policy" {
 }
 
 variable "iam_users" {
-  type = object({
+  type = list(object({
     suffix_name    = string
     policy_actions = list(string)
-  })
+  }))
   description = "IAM users to create"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -147,7 +147,7 @@ variable "s3_bucket_kms_key" {
 
 variable "master_user_iam_enabled" {
   description = "If set to true, the IAM user created by this module will be the master user of the domain."
-  default = false
+  default     = false
 }
 
 variable "master_user_name" {
@@ -185,4 +185,12 @@ variable "tls_security_policy" {
     condition     = contains(["Policy-Min-TLS-1-2-2019-07", "Policy-Min-TLS-1-0-2019-07"], var.tls_security_policy)
     error_message = "Valid values for tls_security_policy are: (Policy-Min-TLS-1-2-2019-07, Policy-Min-TLS-1-0-2019-07)."
   }
+}
+
+variable "iam_users" {
+  type = object({
+    suffix_name    = string
+    policy_actions = list(string)
+  })
+  description = "IAM users to create"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -189,8 +189,8 @@ variable "tls_security_policy" {
 
 variable "iam_users" {
   type = map(list(object({
-    actions = list(string)
-    indexes = list(string)
+    http_methods = list(string)
+    http_paths   = list(string)
   })))
   description = "IAM users to create and their indexes/actions"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -198,7 +198,7 @@ variable "iam_users" {
     condition = alltrue(
       [for user in var.iam_users : alltrue(
         [for policy in user : alltrue(
-          [for method in policy.http_methods : contains(["Post", "Get", "Put", "Delete", "Head", "Patch", "*"], method)])])])
-    error_message = "Supported types are '*', 'Post', 'Get', 'Put', 'Delete', 'Head' and 'Patch'."
+          [for method in policy.http_methods : contains(["POST", "GET", "PUT", "DELETE", "HEAD", "PATCH", "*"], upper(method))])])])
+    error_message = "Supported types are '*', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD' and 'PATCH'."
   }
 }

--- a/variable.tf
+++ b/variable.tf
@@ -192,5 +192,5 @@ variable "iam_users" {
     actions = list(string)
     indexes = list(string)
   })))
-  description = "IAM users to create"
+  description = "IAM users to create and their indexes/actions"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -193,4 +193,12 @@ variable "iam_users" {
     http_paths   = list(string)
   })))
   description = "IAM users to create and their indexes/actions"
+
+  validation {
+    condition = alltrue(
+      [for user in var.iam_users : alltrue(
+        [for policy in user : alltrue(
+          [for method in policy.http_methods : contains(["Post", "Get", "Put", "Delete", "Head", "Patch"], method)])])])
+    error_message = "Supported types are 'Post', 'Get', 'Put', 'Delete', 'Head' and 'Patch'."
+  }
 }

--- a/variable.tf
+++ b/variable.tf
@@ -188,9 +188,9 @@ variable "tls_security_policy" {
 }
 
 variable "iam_users" {
-  type = list(object({
-    name_suffix    = string
-    policy_actions = list(string)
-  }))
+  type = map(list(object({
+    actions = list(string)
+    indexes = list(string)
+  })))
   description = "IAM users to create"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -198,7 +198,7 @@ variable "iam_users" {
     condition = alltrue(
       [for user in var.iam_users : alltrue(
         [for policy in user : alltrue(
-          [for method in policy.http_methods : contains(["Post", "Get", "Put", "Delete", "Head", "Patch"], method)])])])
-    error_message = "Supported types are 'Post', 'Get', 'Put', 'Delete', 'Head' and 'Patch'."
+          [for method in policy.http_methods : contains(["Post", "Get", "Put", "Delete", "Head", "Patch", "*"], method)])])])
+    error_message = "Supported types are '*', 'Post', 'Get', 'Put', 'Delete', 'Head' and 'Patch'."
   }
 }

--- a/variable.tf
+++ b/variable.tf
@@ -189,7 +189,7 @@ variable "tls_security_policy" {
 
 variable "iam_users" {
   type = list(object({
-    suffix_name    = string
+    name_suffix    = string
     policy_actions = list(string)
   }))
   description = "IAM users to create"


### PR DESCRIPTION
Usage:

```module "chris_es_test" {
  source = "git::https://github.com/UKHomeOffice/acp-elasticsearch-tf?ref=ACPENG-1153"

  name        = "chris-test"
  environment = var.environment

  ebs_volume_size                 = "30"
  elasticsearch_version           = "7.4"
  encrypt_at_rest_enabled         = "true"
  instance_count                  = "1"
  instance_type                   = "m5.large.elasticsearch"
  node_to_node_encryption_enabled = "true"
  subnet_ids                      = [""]
  vpc_id                          = var.vpc_id
  zone_awareness_enabled          = "false"
  cidr_blocks                     = values(var.cidrs)

  iam_users = {
    "bar" = [{
      http_paths   = ["bar", "bar/*"],
      http_methods = ["*"]
    }]
    "foo" = [{
      http_paths   = ["foo/*"],
      http_methods = ["Get"]
    }]
}```