### PR TITLE
ACPENG-3033 add policy_sid variable to allow callers to match domain's stored policy SID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "elasticsearch_default_policy_document" {
   count   = var.policy != 0 ? 1 : 0
   version = "2012-10-17"
   statement {
-    sid    = "ElasticsearchPermissions"
+    sid    = var.policy_sid
     effect = "Allow"
     principals {
       type        = "AWS"

--- a/variable.tf
+++ b/variable.tf
@@ -101,6 +101,12 @@ variable "policy" {
   default     = "default"
 }
 
+variable "policy_sid" {
+  description = "The SID for the default Elasticsearch policy statement. Override if the domain was originally created with a different SID to avoid perpetual drift."
+  type        = string
+  default     = "ElasticsearchPermissions"
+}
+
 variable "require_https" {
   type        = string
   default     = "false"


### PR DESCRIPTION
Fix for https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-3033