### PR TITLE
ACPENG-3088 keep audit-log CloudWatch log group and resource policy

### DIFF
--- a/cloudwatch_logs.tf
+++ b/cloudwatch_logs.tf
@@ -1,9 +1,40 @@
 # AUDIT LOGS
 
+locals {
+  create_audit_log_group = var.manage_audit_log_group || var.audit_logs_enabled
+}
+
 resource "aws_cloudwatch_log_group" "elasticsearch_log_group" {
-  count = var.audit_logs_enabled ? 1 : 0
+  count = local.create_audit_log_group ? 1 : 0
   name  = "${var.name}-log-group"
-  tags  = var.tags
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_log_resource_policy" "elasticsearch_log_group_policy" {
+  count = local.create_audit_log_group ? 1 : 0
+
+  policy_name = "${var.name}-log-group-policy"
+
+  policy_document = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "es.amazonaws.com"
+      },
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:PutLogEventsBatch",
+        "logs:CreateLogStream"
+      ],
+      "Resource": "arn:aws:logs:*"
+    }
+  ]
+}
+CONFIG
 }
 
 resource "aws_iam_user" "elasticsearch_audit_logs_iam_user" {

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "aws_elasticsearch_domain" "elasticsearch" {
 
   log_publishing_options {
     enabled                  = var.audit_logs_enabled
-    cloudwatch_log_group_arn = var.audit_logs_enabled ? aws_cloudwatch_log_group.elasticsearch_log_group[0].arn : ""
+    cloudwatch_log_group_arn = local.create_audit_log_group ? aws_cloudwatch_log_group.elasticsearch_log_group[0].arn : ""
     log_type                 = "AUDIT_LOGS"
   }
 

--- a/variable.tf
+++ b/variable.tf
@@ -183,6 +183,12 @@ variable "audit_logs_enabled" {
   default     = false
 }
 
+variable "manage_audit_log_group" {
+  type        = bool
+  description = "Manage the audit-log CloudWatch log group and its log resource policy. Defaults to true so existing domains keep them on upgrade; set false for new domains that do not need them. The log group is always created when audit_logs_enabled is true."
+  default     = true
+}
+
 variable "tls_security_policy" {
   type        = string
   description = "Default TLS security policy. Which controls the minimum TLS version required for traffic to the domain. Valid values Policy-Min-TLS-1-0-2019-07 Policy-Min-TLS-1-2-2019-07"


### PR DESCRIPTION
## What

Restore the audit-log CloudWatch resources in this module to being **always managed**:

- Removed the `audit_logs_enabled` count gate on `aws_cloudwatch_log_group.elasticsearch_log_group` — the log group is created regardless of whether audit logging is enabled.
- Restored the `aws_cloudwatch_log_resource_policy.elasticsearch_log_group_policy` resource (the permission that lets `es.amazonaws.com` deliver logs).
- `log_publishing_options.cloudwatch_log_group_arn` now references the real log group ARN unconditionally, instead of `""` when audit logging is off.

The audit-log *reader* IAM user/policy stay gated behind `audit_logs_enabled` — unchanged.

## Why

Since the audit-log refactor, the log group was gated behind `audit_logs_enabled` and the resource policy was dropped from the module. For any existing domain with audit logging disabled, upgrading the module:

- **destroys** the CloudWatch log group and resource policy, and
- produces a spurious in-place change on the domain (`log_publishing_options` ARN cleared to `""`).

That makes the upgrade destructive for existing tenants and removes the log-delivery permission. This change makes the upgrade **non-destructive** — existing domains keep these resources with no drift, and the module still works the same for new domains.

## Impact

- Opt-in: only affects callers who bump to this version.
- New domains created with audit logging off will now also get an (empty, low-cost) log group + resource policy.
